### PR TITLE
docs: fix key builder refs

### DIFF
--- a/docs/src/content/docs/examples/basic-crud-operations.md
+++ b/docs/src/content/docs/examples/basic-crud-operations.md
@@ -73,10 +73,8 @@ const todoEntity = new DynamoEntity({
     createdAt: isoDatetime().default(() => new Date()),
     isCompleted: z.boolean().default(false),
   }),
-  keys: {
-    partitionKey: todo => key('USER_TODO', todo.userId),
-    sortKey: todo => key('TODO', todo.todoId, 'CREATED_AT', todo.createdAt),
-  },
+  partitionKey: todo => key('USER_TODO', todo.userId),
+  sortKey: todo => key('TODO', todo.todoId, 'CREATED_AT', todo.createdAt),
 });
 type Todo = Entity<typeof todoEntity>;
 ```

--- a/docs/src/content/docs/quick-start/defining-entities.mdx
+++ b/docs/src/content/docs/quick-start/defining-entities.mdx
@@ -32,7 +32,7 @@ In the above example, we might use `USER#123#TODO#456` as the `PK` where the `12
 
 Document Builder makes this easier by enabling you to compute your primary keys from your data that's already in the schema:
 
-```ts {6-7,10} ins={12-15}
+```ts {6-7,10} ins={12-13}
 import { key } from 'dynamo-document-builder';
 
 const todoEntity = new DynamoEntity({
@@ -44,10 +44,8 @@ const todoEntity = new DynamoEntity({
     isComplete: z.boolean().default(false),
     createdAt: z.iso.date(),
   }),
-  keys: {
-    partitionKey: todo => key('USER', todo.userId, 'TODO', todo.todoId),
-    sortKey: todo => key('CREATED_AT', todo.createdAt),
-  }
+  partitionKey: todo => key('USER', todo.userId, 'TODO', todo.todoId),
+  sortKey: todo => key('CREATED_AT', todo.createdAt),
 })
 ```
 
@@ -103,10 +101,8 @@ const todoEntity = new DynamoEntity({
     isComplete: z.boolean().default(false),
     createdAt: z.iso.date(),
   }),
-  keys: {
-    partitionKey: todo => key('USER', todo.userId, 'TODO', todo.todoId),
-    sortKey: todo => key('CREATED_AT', todo.createdAt),
-  }
+  partitionKey: todo => key('USER', todo.userId, 'TODO', todo.todoId),
+  sortKey: todo => key('CREATED_AT', todo.createdAt),
 })
 
 type TodoEntity = Entity<typeof todoEntity>;


### PR DESCRIPTION
## Description

Fix doc refs to entity key builders using outdated `keys` in the entity config.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Dependency updates

## Related Issues

N/A

## Testing

<!-- Describe the testing you performed -->

- [x] Unit tests pass (`npm test`)
- [x] Integration tests pass (`npm run test:integration`)
- [x] Type checking passes (`npm run typecheck`)
- [x] Linting passes (`npm run lint`)
- [x] Added new tests for changes
- [x] Manually tested changes

## Documentation

- [x] Updated documentation (if applicable)
- [ ] Added/updated code comments (if applicable)

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

N/A

## Additional Context

<!-- Add any other context, screenshots, or information about the PR here -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
