### PR TITLE
fix: add missing lib for AsyncIterableIterator global type

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2016",
+    "lib": ["es2016", "esnext.asynciterable"],
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "noLib": false,


### PR DESCRIPTION
## Summary
- Adds `"lib": ["es2016", "esnext.asynciterable"]` to the root `tsconfig.json` to fix `TS2318: Cannot find global type 'AsyncIterableIterator'` build error
- TypeScript 5.6+ requires this type in the lib when `strictBuiltinIteratorReturn` is enabled