### PR TITLE
fix: resolve typedoc compilation errors in Netlify build

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -145,7 +145,7 @@ export default defineConfig({
             collapsed: true,
           },
           entryPoints: ['../src/index.ts'],
-          tsconfig: '../tsconfig.json',
+          tsconfig: '../tsconfig.typedoc.json',
           pagination: false,
           typeDoc: {
             name: 'API Reference',

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   base = "docs"
-  command = "npm install && npm run build"
+  command = "npm install --prefix .. && npm install && npm run build"
   publish = "dist"
 
 [[headers]]

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["es2020", "esnext.asynciterable", "dom"],
+    "types": ["node"],
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `tsconfig.typedoc.json` extending the root tsconfig with broader `lib` (`es2020`, `dom`) and `@types/node` to satisfy typedoc's full compilation of source files (AsyncGenerator, AbortSignal, Object.entries, Buffer, etc.)
- Points the starlight-typedoc plugin at the new tsconfig instead of the root one
- Updates the Netlify build command to install root dependencies first (`npm install --prefix ..`) so typedoc can resolve `@aws-sdk/*`, `zod/v4`, and `p-map`