### PR TITLE
feat: broaden schema constraint from ZodObject to ObjectLikeZodType

### DIFF
--- a/src/commands/batch-get.ts
+++ b/src/commands/batch-get.ts
@@ -1,7 +1,6 @@
 import type { BaseConfig, BaseCommand, BaseResult, BatchGetPreparable } from '@/commands'
 import type { DynamoEntity } from '@/core/entity'
-import type { EntitySchema } from '@/core'
-import type { ZodObject } from 'zod/v4'
+import type { EntitySchema, ObjectLikeZodType } from '@/core'
 import { BATCH_GET_VALIDATION_CONCURRENCY } from '@/internal-constants'
 import { BatchGetCommand } from '@aws-sdk/lib-dynamodb'
 import pMap from 'p-map'
@@ -11,7 +10,7 @@ import pMap from 'p-map'
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type BatchGetConfig<Schema extends ZodObject> = BaseConfig & {
+export type BatchGetConfig<Schema extends ObjectLikeZodType> = BaseConfig & {
   keys: Array<Partial<EntitySchema<Schema>>>
   consistent?: boolean
 }
@@ -21,7 +20,7 @@ export type BatchGetConfig<Schema extends ZodObject> = BaseConfig & {
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type BatchGetResult<Schema extends ZodObject> = BaseResult & {
+export type BatchGetResult<Schema extends ObjectLikeZodType> = BaseResult & {
   items: Array<EntitySchema<Schema>>
   unprocessedKeys?: Array<Partial<EntitySchema<Schema>>>
 }
@@ -62,7 +61,7 @@ export type BatchGetResult<Schema extends ZodObject> = BaseResult & {
  * const { items } = await batchGetCommand.execute(userEntity);
  * ```
  */
-export class BatchGet<Schema extends ZodObject>
+export class BatchGet<Schema extends ObjectLikeZodType>
   implements BaseCommand<BatchGetResult<Schema>, Schema>, BatchGetPreparable<Schema>
 {
   #config: BatchGetConfig<Schema>

--- a/src/commands/batch-projected-get.ts
+++ b/src/commands/batch-projected-get.ts
@@ -1,8 +1,7 @@
 import type { BaseConfig, BaseCommand, BaseResult } from '@/commands'
 import type { DynamoEntity } from '@/core/entity'
-import type { EntitySchema } from '@/core'
+import type { EntitySchema, ObjectLikeZodType } from '@/core'
 import type { Projection } from '@/projections'
-import type { ZodObject } from 'zod/v4'
 import { BATCH_GET_VALIDATION_CONCURRENCY } from '@/internal-constants'
 import { BatchGetCommand } from '@aws-sdk/lib-dynamodb'
 import { parseProjection } from '@/projections/projection-parser'
@@ -15,8 +14,8 @@ import pMap from 'p-map'
  * @template ProjectionSchema - The Zod schema defining the structure of the projected attributes.
  */
 export type BatchProjectedGetConfig<
-  Schema extends ZodObject,
-  ProjectionSchema extends ZodObject,
+  Schema extends ObjectLikeZodType,
+  ProjectionSchema extends ObjectLikeZodType,
 > = BaseConfig & {
   keys: Array<Partial<EntitySchema<Schema>>>
   consistent?: boolean
@@ -29,7 +28,7 @@ export type BatchProjectedGetConfig<
  *
  * @template ProjectionSchema - The Zod schema defining the structure of the projected attributes.
  */
-export type BatchProjectedGetResult<ProjectionSchema extends ZodObject> = BaseResult & {
+export type BatchProjectedGetResult<ProjectionSchema extends ObjectLikeZodType> = BaseResult & {
   items: Array<EntitySchema<ProjectionSchema>>
   unprocessedKeys?: Array<Partial<EntitySchema<ProjectionSchema>>>
 }
@@ -76,8 +75,10 @@ export type BatchProjectedGetResult<ProjectionSchema extends ZodObject> = BaseRe
  * const { items } = await userEntity.send(batchProjectedGetCommand);
  * ```
  */
-export class BatchProjectedGet<Schema extends ZodObject, ProjectionSchema extends ZodObject>
-  implements BaseCommand<BatchProjectedGetResult<ProjectionSchema>, Schema>
+export class BatchProjectedGet<
+  Schema extends ObjectLikeZodType,
+  ProjectionSchema extends ObjectLikeZodType,
+> implements BaseCommand<BatchProjectedGetResult<ProjectionSchema>, Schema>
 {
   #config: BatchProjectedGetConfig<Schema, ProjectionSchema>
 

--- a/src/commands/batch-write.ts
+++ b/src/commands/batch-write.ts
@@ -1,8 +1,7 @@
 import type { BaseConfig, BaseCommand, BaseResult, BatchWritePreparable } from '@/commands'
 import type { DynamoEntity } from '@/core/entity'
-import type { EntitySchema } from '@/core'
+import type { EntitySchema, ObjectLikeZodType } from '@/core'
 import type { ItemCollectionMetrics, ReturnItemCollectionMetrics } from '@aws-sdk/client-dynamodb'
-import type { ZodObject } from 'zod/v4'
 import { BATCH_WRITE_VALIDATION_CONCURRENCY } from '@/internal-constants'
 import { BatchWriteCommand } from '@aws-sdk/lib-dynamodb'
 import pMap from 'p-map'
@@ -12,7 +11,7 @@ import pMap from 'p-map'
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type BatchWriteConfig<Schema extends ZodObject> = BaseConfig & {
+export type BatchWriteConfig<Schema extends ObjectLikeZodType> = BaseConfig & {
   items?: Array<EntitySchema<Schema>>
   deletes?: Array<Partial<EntitySchema<Schema>>>
   returnItemCollectionMetrics?: ReturnItemCollectionMetrics
@@ -23,7 +22,7 @@ export type BatchWriteConfig<Schema extends ZodObject> = BaseConfig & {
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type BatchWriteResult<Schema extends ZodObject> = BaseResult & {
+export type BatchWriteResult<Schema extends ObjectLikeZodType> = BaseResult & {
   unprocessedPuts?: Array<EntitySchema<Schema>>
   unprocessedDeletes?: Array<Partial<EntitySchema<Schema>>>
   itemColectionMetrics?: ItemCollectionMetrics
@@ -67,7 +66,7 @@ export type BatchWriteResult<Schema extends ZodObject> = BaseResult & {
  * const { unprocessedPuts, unprocessedDeletes } = await todoEntity.send(batchWriteCommand);
  * ```
  */
-export class BatchWrite<Schema extends ZodObject>
+export class BatchWrite<Schema extends ObjectLikeZodType>
   implements BaseCommand<BatchWriteResult<Schema>, Schema>, BatchWritePreparable<Schema>
 {
   #config: BatchWriteConfig<Schema>
@@ -105,7 +104,7 @@ export class BatchWrite<Schema extends ZodObject>
         return {
           PutRequest: {
             Item: {
-              ...encodedData,
+              ...(encodedData as Record<string, unknown>),
               ...entity.buildAllKeys(item),
             },
           },

--- a/src/commands/condition-check.ts
+++ b/src/commands/condition-check.ts
@@ -1,9 +1,8 @@
 import type { Condition } from '@/conditions'
 import type { DynamoEntity } from '@/core/entity'
-import type { EntitySchema, TransactWriteOperation } from '@/core'
+import type { EntitySchema, TransactWriteOperation, ObjectLikeZodType } from '@/core'
 import type { ReturnValuesOnConditionCheckFailure } from '@aws-sdk/client-dynamodb'
 import type { WriteTransactable } from '@/commands'
-import type { ZodObject } from 'zod/v4'
 import { parseCondition } from '@/conditions/condition-parser'
 
 /**
@@ -11,7 +10,7 @@ import { parseCondition } from '@/conditions/condition-parser'
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type ConditionCheckConfig<Schema extends ZodObject> = {
+export type ConditionCheckConfig<Schema extends ObjectLikeZodType> = {
   key: Partial<EntitySchema<Schema>>
   condition: Condition
   returnValuesOnConditionCheckFailure?: ReturnValuesOnConditionCheckFailure
@@ -54,7 +53,7 @@ export type ConditionCheckConfig<Schema extends ZodObject> = {
  * await userEntity.send(transactWriteCommand);
  * ```
  */
-export class ConditionCheck<Schema extends ZodObject> implements WriteTransactable<Schema> {
+export class ConditionCheck<Schema extends ObjectLikeZodType> implements WriteTransactable<Schema> {
   #config: ConditionCheckConfig<Schema>
 
   constructor(config: ConditionCheckConfig<Schema>) {

--- a/src/commands/conditional-delete.ts
+++ b/src/commands/conditional-delete.ts
@@ -1,12 +1,12 @@
 import type { Condition } from '@/conditions'
 import type { DeleteConfig } from '@/commands/delete'
 import type { DynamoEntity } from '@/core/entity'
-import type { EntitySchema, TransactWriteOperation } from '@/core'
+import type { EntitySchema, TransactWriteOperation, ObjectLikeZodType } from '@/core'
+import { parsePartial } from '@/core'
 import type {
   ItemCollectionMetrics,
   ReturnValuesOnConditionCheckFailure,
 } from '@aws-sdk/client-dynamodb'
-import type { ZodObject } from 'zod/v4'
 import { DeleteCommand } from '@aws-sdk/lib-dynamodb'
 import { parseCondition } from '@/conditions/condition-parser'
 import type { BaseResult, BaseCommand, WriteTransactable } from '@/commands'
@@ -16,7 +16,7 @@ import type { BaseResult, BaseCommand, WriteTransactable } from '@/commands'
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type ConditionalDeleteConfig<Schema extends ZodObject> = DeleteConfig<Schema> & {
+export type ConditionalDeleteConfig<Schema extends ObjectLikeZodType> = DeleteConfig<Schema> & {
   condition: Condition
   returnValuesOnConditionCheckFailure?: ReturnValuesOnConditionCheckFailure
 }
@@ -26,7 +26,7 @@ export type ConditionalDeleteConfig<Schema extends ZodObject> = DeleteConfig<Sch
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type ConditionalDeleteResult<Schema extends ZodObject> = BaseResult & {
+export type ConditionalDeleteResult<Schema extends ObjectLikeZodType> = BaseResult & {
   deletedItem?: Partial<EntitySchema<Schema>> | undefined
   itemCollectionMetrics?: ItemCollectionMetrics
 }
@@ -64,7 +64,7 @@ export type ConditionalDeleteResult<Schema extends ZodObject> = BaseResult & {
  * const { deletedItem } = await userEntity.send(conditionalDeleteCommand);
  * ```
  */
-export class ConditionalDelete<Schema extends ZodObject>
+export class ConditionalDelete<Schema extends ObjectLikeZodType>
   implements BaseCommand<ConditionalDeleteResult<Schema>, Schema>, WriteTransactable<Schema>
 {
   #config: ConditionalDeleteConfig<Schema>
@@ -97,9 +97,7 @@ export class ConditionalDelete<Schema extends ZodObject>
       if (this.#config.skipValidation) {
         deletedItem = deleteResult.Attributes as Partial<EntitySchema<Schema>>
       } else {
-        deletedItem = (await entity.schema
-          .partial()
-          .parseAsync(deleteResult.Attributes)) as Partial<EntitySchema<Schema>>
+        deletedItem = await parsePartial(entity.schema, deleteResult.Attributes)
       }
     }
 

--- a/src/commands/conditional-put.ts
+++ b/src/commands/conditional-put.ts
@@ -1,12 +1,11 @@
 import type { Condition } from '@/conditions'
 import type { DynamoEntity } from '@/core/entity'
-import type { EntitySchema, TransactWriteOperation } from '@/core'
+import type { EntitySchema, TransactWriteOperation, ObjectLikeZodType } from '@/core'
 import type {
   ItemCollectionMetrics,
   ReturnValuesOnConditionCheckFailure,
 } from '@aws-sdk/client-dynamodb'
 import type { PutConfig } from '@/commands/put'
-import type { ZodObject } from 'zod/v4'
 import { PutCommand } from '@aws-sdk/lib-dynamodb'
 import { parseCondition } from '@/conditions/condition-parser'
 import type { BaseResult, BaseCommand, WriteTransactable } from '@/commands'
@@ -16,7 +15,7 @@ import type { BaseResult, BaseCommand, WriteTransactable } from '@/commands'
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type ConditionalPutConfig<Schema extends ZodObject> = PutConfig<Schema> & {
+export type ConditionalPutConfig<Schema extends ObjectLikeZodType> = PutConfig<Schema> & {
   condition: Condition
   returnValuesOnConditionCheckFailure?: ReturnValuesOnConditionCheckFailure
 }
@@ -26,7 +25,7 @@ export type ConditionalPutConfig<Schema extends ZodObject> = PutConfig<Schema> &
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type ConditionalPutResult<Schema extends ZodObject> = BaseResult & {
+export type ConditionalPutResult<Schema extends ObjectLikeZodType> = BaseResult & {
   returnItem: EntitySchema<Schema> | undefined
   itemCollectionMetrics: ItemCollectionMetrics | undefined
 }
@@ -65,7 +64,7 @@ export type ConditionalPutResult<Schema extends ZodObject> = BaseResult & {
  * await userEntity.send(conditionalPutCommand);
  * ```
  */
-export class ConditionalPut<Schema extends ZodObject>
+export class ConditionalPut<Schema extends ObjectLikeZodType>
   implements BaseCommand<ConditionalPutResult<Schema>, Schema>, WriteTransactable<Schema>
 {
   #config: ConditionalPutConfig<Schema>
@@ -80,7 +79,7 @@ export class ConditionalPut<Schema extends ZodObject>
       : await entity.schema.encodeAsync(this.#config.item)
 
     return {
-      ...encodedData,
+      ...(encodedData as Record<string, unknown>),
       ...entity.buildAllKeys(this.#config.item),
     }
   }

--- a/src/commands/conditional-update.ts
+++ b/src/commands/conditional-update.ts
@@ -1,12 +1,11 @@
 import type { Condition } from '@/conditions'
 import type { DynamoEntity } from '@/core/entity'
-import type { EntitySchema, TransactWriteOperation } from '@/core'
+import type { EntitySchema, TransactWriteOperation, ObjectLikeZodType } from '@/core'
 import type {
   ItemCollectionMetrics,
   ReturnValuesOnConditionCheckFailure,
 } from '@aws-sdk/client-dynamodb'
 import type { UpdateConfig } from '@/commands/update'
-import type { ZodObject } from 'zod/v4'
 import { AttributeExpressionMap } from '@/attributes'
 import { UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import { parseCondition } from '@/conditions/condition-parser'
@@ -18,7 +17,7 @@ import type { BaseResult, BaseCommand, WriteTransactable } from '@/commands'
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type ConditionalUpdateConfig<Schema extends ZodObject> = UpdateConfig<Schema> & {
+export type ConditionalUpdateConfig<Schema extends ObjectLikeZodType> = UpdateConfig<Schema> & {
   condition: Condition
   returnValuesOnConditionCheckFailure?: ReturnValuesOnConditionCheckFailure
 }
@@ -28,7 +27,7 @@ export type ConditionalUpdateConfig<Schema extends ZodObject> = UpdateConfig<Sch
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type ConditionalUpdateResult<Schema extends ZodObject> = BaseResult & {
+export type ConditionalUpdateResult<Schema extends ObjectLikeZodType> = BaseResult & {
   updatedItem?: EntitySchema<Schema> | undefined
   itemCollectionMetrics?: ItemCollectionMetrics
 }
@@ -68,7 +67,7 @@ export type ConditionalUpdateResult<Schema extends ZodObject> = BaseResult & {
  * const { updatedItem } = await userEntity.send(conditionalUpdateCommand);
  * ```
  */
-export class ConditionalUpdate<Schema extends ZodObject>
+export class ConditionalUpdate<Schema extends ObjectLikeZodType>
   implements BaseCommand<ConditionalUpdateResult<Schema>, Schema>, WriteTransactable<Schema>
 {
   #config: ConditionalUpdateConfig<Schema>

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -1,11 +1,11 @@
 import type { DynamoEntity } from '@/core/entity'
-import type { EntitySchema, TransactWriteOperation } from '@/core'
+import type { EntitySchema, TransactWriteOperation, ObjectLikeZodType } from '@/core'
+import { parsePartial } from '@/core'
 import type {
   ItemCollectionMetrics,
   ReturnItemCollectionMetrics,
   ReturnValue,
 } from '@aws-sdk/client-dynamodb'
-import type { ZodObject } from 'zod/v4'
 import { DeleteCommand } from '@aws-sdk/lib-dynamodb'
 import type { BaseConfig, BaseCommand, BaseResult, WriteTransactable } from '@/commands'
 
@@ -14,7 +14,7 @@ import type { BaseConfig, BaseCommand, BaseResult, WriteTransactable } from '@/c
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type DeleteConfig<Schema extends ZodObject> = BaseConfig & {
+export type DeleteConfig<Schema extends ObjectLikeZodType> = BaseConfig & {
   key: Partial<EntitySchema<Schema>>
   returnValues?: ReturnValue
   returnItemCollectionMetrics?: ReturnItemCollectionMetrics
@@ -25,7 +25,7 @@ export type DeleteConfig<Schema extends ZodObject> = BaseConfig & {
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type DeleteResult<Schema extends ZodObject> = BaseResult & {
+export type DeleteResult<Schema extends ObjectLikeZodType> = BaseResult & {
   deletedItem?: Partial<EntitySchema<Schema>> | undefined
   itemCollectionMetrics?: ItemCollectionMetrics
 }
@@ -62,7 +62,7 @@ export type DeleteResult<Schema extends ZodObject> = BaseResult & {
  * const { deletedItem } = await userEntity.send(deleteCommand);
  * ```
  */
-export class Delete<Schema extends ZodObject>
+export class Delete<Schema extends ObjectLikeZodType>
   implements BaseCommand<DeleteResult<Schema>, Schema>, WriteTransactable<Schema>
 {
   #config: DeleteConfig<Schema>
@@ -90,9 +90,7 @@ export class Delete<Schema extends ZodObject>
       if (this.#config.skipValidation) {
         deletedItem = deleteResult.Attributes as Partial<EntitySchema<Schema>>
       } else {
-        deletedItem = (await entity.schema
-          .partial()
-          .parseAsync(deleteResult.Attributes)) as Partial<EntitySchema<Schema>>
+        deletedItem = await parsePartial(entity.schema, deleteResult.Attributes)
       }
     }
 

--- a/src/commands/get.ts
+++ b/src/commands/get.ts
@@ -1,15 +1,14 @@
 import { GetCommand } from '@aws-sdk/lib-dynamodb'
 import type { DynamoEntity } from '@/core/entity'
 import type { BaseConfig, BaseCommand, BaseResult } from '@/commands'
-import type { ZodObject } from 'zod/v4'
-import type { EntitySchema } from '@/core'
+import type { EntitySchema, ObjectLikeZodType } from '@/core'
 
 /**
  * Configuration for the Get command.
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type GetConfig<Schema extends ZodObject> = BaseConfig & {
+export type GetConfig<Schema extends ObjectLikeZodType> = BaseConfig & {
   key: Partial<EntitySchema<Schema>>
   consistent?: boolean
 }
@@ -19,7 +18,7 @@ export type GetConfig<Schema extends ZodObject> = BaseConfig & {
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type GetResult<Schema extends ZodObject> = BaseResult & {
+export type GetResult<Schema extends ObjectLikeZodType> = BaseResult & {
   item: EntitySchema<Schema> | undefined
 }
 
@@ -56,7 +55,9 @@ export type GetResult<Schema extends ZodObject> = BaseResult & {
  * const { item } = await userEntity.send(getCommand);
  * ```
  */
-export class Get<Schema extends ZodObject> implements BaseCommand<GetResult<Schema>, Schema> {
+export class Get<Schema extends ObjectLikeZodType>
+  implements BaseCommand<GetResult<Schema>, Schema>
+{
   #config: GetConfig<Schema>
 
   constructor(config: GetConfig<Schema>) {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,18 +1,17 @@
-import type { TransactWriteOperation } from '@/core'
+import type { TransactWriteOperation, ObjectLikeZodType } from '@/core'
 import type { DynamoEntity } from '@/core/entity'
 import type { DynamoTable } from '@/core/table'
 import type { EntitySchema } from '@/core'
 import type { DynamoKey } from '@/core/key'
 import type { ConsumedCapacity, ReturnConsumedCapacity } from '@aws-sdk/client-dynamodb'
 import type { ResponseMetadata } from '@aws-sdk/types'
-import type { ZodObject } from 'zod/v4'
 
 /**
  * Interface for commands that can be prepared for use in a table-level batch write.
  *
  * @template Schema The Zod schema type associated with the DynamoEntity.
  */
-export type BatchWritePreparable<Schema extends ZodObject> = {
+export type BatchWritePreparable<Schema extends ObjectLikeZodType> = {
   readonly items?: Array<EntitySchema<Schema>>
   readonly deletes?: Array<Partial<EntitySchema<Schema>>>
 }
@@ -22,7 +21,7 @@ export type BatchWritePreparable<Schema extends ZodObject> = {
  *
  * @template Schema The Zod schema type associated with the DynamoEntity.
  */
-export type BatchGetPreparable<Schema extends ZodObject> = {
+export type BatchGetPreparable<Schema extends ObjectLikeZodType> = {
   readonly keys: Array<Partial<EntitySchema<Schema>>>
   readonly consistent?: boolean
 }
@@ -35,7 +34,7 @@ export type BatchGetPreparable<Schema extends ZodObject> = {
  * @template Output The output type of the command's execute method.
  * @template Schema The Zod schema type associated with the DynamoEntity.
  */
-export type BaseCommand<Output, Schema extends ZodObject> = {
+export type BaseCommand<Output, Schema extends ObjectLikeZodType> = {
   execute(entity: DynamoEntity<Schema>): Promise<Output>
 }
 
@@ -47,7 +46,7 @@ export type BaseCommand<Output, Schema extends ZodObject> = {
  * @template Output The output type of the command's executePaginated method.
  * @template Schema The Zod schema type associated with the DynamoEntity.
  */
-export type BasePaginatable<Output, Schema extends ZodObject> = {
+export type BasePaginatable<Output, Schema extends ObjectLikeZodType> = {
   executePaginated(entity: DynamoEntity<Schema>): AsyncGenerator<Output, void, unknown>
 }
 
@@ -56,7 +55,7 @@ export type BasePaginatable<Output, Schema extends ZodObject> = {
  *
  * @template Schema The Zod schema type associated with the DynamoEntity.
  */
-export type GetTransactable<Schema extends ZodObject> = {
+export type GetTransactable<Schema extends ObjectLikeZodType> = {
   readonly keys: Array<Partial<EntitySchema<Schema>>>
 }
 
@@ -65,7 +64,7 @@ export type GetTransactable<Schema extends ZodObject> = {
  *
  * @template Schema The Zod schema type associated with the DynamoEntity.
  */
-export type WriteTransactable<Schema extends ZodObject> = {
+export type WriteTransactable<Schema extends ObjectLikeZodType> = {
   prepareWriteTransaction(entity: DynamoEntity<Schema>): Promise<TransactWriteOperation>
 }
 
@@ -84,7 +83,7 @@ export type TableCommand<Output> = {
  *
  * @template Schema The Zod schema type associated with the DynamoEntity.
  */
-export type PreparedWriteTransaction<Schema extends ZodObject> = {
+export type PreparedWriteTransaction<Schema extends ObjectLikeZodType> = {
   entity: DynamoEntity<Schema>
   writes: WriteTransactable<Schema>[]
 }
@@ -95,7 +94,7 @@ export type PreparedWriteTransaction<Schema extends ZodObject> = {
  *
  * @template Schema The Zod schema type associated with the DynamoEntity.
  */
-export type PreparedGetTransaction<Schema extends ZodObject> = {
+export type PreparedGetTransaction<Schema extends ObjectLikeZodType> = {
   entity: DynamoEntity<Schema>
   keys: Array<{ TableName: string; Key: DynamoKey }>
   parseResults(
@@ -110,7 +109,7 @@ export type PreparedGetTransaction<Schema extends ZodObject> = {
  *
  * @template Schema The Zod schema type associated with the DynamoEntity.
  */
-export type PreparedBatchWrite<Schema extends ZodObject> = {
+export type PreparedBatchWrite<Schema extends ObjectLikeZodType> = {
   entity: DynamoEntity<Schema>
   buildRequests(
     skipValidation: boolean,
@@ -128,7 +127,7 @@ export type PreparedBatchWrite<Schema extends ZodObject> = {
  *
  * @template Schema The Zod schema type associated with the DynamoEntity.
  */
-export type PreparedBatchGet<Schema extends ZodObject> = {
+export type PreparedBatchGet<Schema extends ObjectLikeZodType> = {
   entity: DynamoEntity<Schema>
   keys: Array<DynamoKey>
   consistent: boolean

--- a/src/commands/projected-get.ts
+++ b/src/commands/projected-get.ts
@@ -1,8 +1,7 @@
 import type { DynamoEntity } from '@/core/entity'
-import type { EntitySchema } from '@/core'
+import type { EntitySchema, ObjectLikeZodType } from '@/core'
 import type { GetConfig } from '@/commands/get'
 import type { Projection } from '@/projections'
-import type { ZodObject } from 'zod/v4'
 import { GetCommand } from '@aws-sdk/lib-dynamodb'
 import { parseProjection } from '@/projections/projection-parser'
 import type { BaseResult, BaseCommand } from '@/commands'
@@ -14,8 +13,8 @@ import type { BaseResult, BaseCommand } from '@/commands'
  * @template ProjectionSchema - The Zod schema defining the structure of the projected attributes.
  */
 export type ProjectedGetConfig<
-  Schema extends ZodObject,
-  ProjectionSchema extends ZodObject,
+  Schema extends ObjectLikeZodType,
+  ProjectionSchema extends ObjectLikeZodType,
 > = GetConfig<Schema> & {
   projection: Projection
   projectionSchema: ProjectionSchema
@@ -26,7 +25,7 @@ export type ProjectedGetConfig<
  *
  * @template ProjectionSchema - The Zod schema defining the structure of the projected attributes.
  */
-export type ProjectedGetResult<ProjectionSchema extends ZodObject> = BaseResult & {
+export type ProjectedGetResult<ProjectionSchema extends ObjectLikeZodType> = BaseResult & {
   item: EntitySchema<ProjectionSchema> | undefined
 }
 
@@ -70,8 +69,10 @@ export type ProjectedGetResult<ProjectionSchema extends ZodObject> = BaseResult 
  * const { item } = await userEntity.send(projectedGetCommand);
  * ```
  */
-export class ProjectedGet<Schema extends ZodObject, ProjectionSchema extends ZodObject>
-  implements BaseCommand<ProjectedGetResult<ProjectionSchema>, Schema>
+export class ProjectedGet<
+  Schema extends ObjectLikeZodType,
+  ProjectionSchema extends ObjectLikeZodType,
+> implements BaseCommand<ProjectedGetResult<ProjectionSchema>, Schema>
 {
   #config: ProjectedGetConfig<Schema, ProjectionSchema>
 

--- a/src/commands/projected-query.ts
+++ b/src/commands/projected-query.ts
@@ -1,8 +1,7 @@
 import type { DynamoEntity } from '@/core/entity'
-import type { EntitySchema } from '@/core'
+import type { EntitySchema, ObjectLikeZodType } from '@/core'
 import type { Projection } from '@/projections'
 import type { QueryConfig } from '@/commands/query'
-import type { ZodObject } from 'zod/v4'
 import { AttributeExpressionMap } from '@/attributes/attribute-map'
 import { PROJECTED_QUERY_VALIDATION_CONCURRENCY } from '@/internal-constants'
 import { parseCondition } from '@/conditions/condition-parser'
@@ -25,8 +24,8 @@ import pMap from 'p-map'
  * @template ProjectionSchema - The Zod schema defining the structure of the projected attributes.
  */
 export type ProjectedQueryConfig<
-  Schema extends ZodObject,
-  ProjectionSchema extends ZodObject,
+  Schema extends ObjectLikeZodType,
+  ProjectionSchema extends ObjectLikeZodType,
 > = QueryConfig<Schema> & {
   projection: Projection
   projectionSchema: ProjectionSchema
@@ -39,8 +38,8 @@ export type ProjectedQueryConfig<
  * @template ProjectionSchema - The Zod schema defining the structure of the projected attributes.
  */
 export type ProjectedQueryResult<
-  Schema extends ZodObject,
-  ProjectionSchema extends ZodObject,
+  Schema extends ObjectLikeZodType,
+  ProjectionSchema extends ObjectLikeZodType,
 > = BaseResult & {
   items: EntitySchema<ProjectionSchema>[]
   count: number
@@ -89,8 +88,10 @@ export type ProjectedQueryResult<
  * const { items, count } = await todoEntity.send(projectedQueryCommand);
  * ```
  */
-export class ProjectedQuery<Schema extends ZodObject, ProjectedSchema extends ZodObject>
-  implements
+export class ProjectedQuery<
+  Schema extends ObjectLikeZodType,
+  ProjectedSchema extends ObjectLikeZodType,
+> implements
     BaseCommand<ProjectedQueryResult<Schema, ProjectedSchema>, Schema>,
     BasePaginatable<ProjectedQueryResult<Schema, ProjectedSchema>, Schema>
 {

--- a/src/commands/projected-scan.ts
+++ b/src/commands/projected-scan.ts
@@ -1,8 +1,7 @@
 import type { DynamoEntity } from '@/core/entity'
-import type { EntitySchema } from '@/core'
+import type { EntitySchema, ObjectLikeZodType } from '@/core'
 import type { ScanConfig } from '@/commands/scan'
 import type { Projection } from '@/projections'
-import type { ZodObject } from 'zod/v4'
 import { AttributeExpressionMap } from '@/attributes/attribute-map'
 import type { BaseCommand, BasePaginatable, BaseResult } from '@/commands'
 import { PROJECTED_SCAN_VALIDATION_CONCURRENCY } from '@/internal-constants'
@@ -22,7 +21,7 @@ import pMap from 'p-map'
  *
  * @template ProjectionSchema - The Zod schema defining the structure of the projected attributes.
  */
-export type ProjectedScanConfig<ProjectionSchema extends ZodObject> =
+export type ProjectedScanConfig<ProjectionSchema extends ObjectLikeZodType> =
   ScanConfig<ProjectionSchema> & {
     projection: Projection
     projectionSchema: ProjectionSchema
@@ -35,8 +34,8 @@ export type ProjectedScanConfig<ProjectionSchema extends ZodObject> =
  * @template ProjectionSchema - The Zod schema defining the structure of the projected attributes.
  */
 export type ProjectedScanResult<
-  Schema extends ZodObject,
-  ProjectionSchema extends ZodObject,
+  Schema extends ObjectLikeZodType,
+  ProjectionSchema extends ObjectLikeZodType,
 > = BaseResult & {
   items: EntitySchema<ProjectionSchema>[]
   count: number
@@ -85,8 +84,10 @@ export type ProjectedScanResult<
  * const { items, scannedCount } = await todoEntity.send(projectedScanCommand);
  * ```
  */
-export class ProjectedScan<Schema extends ZodObject, ProjectedSchema extends ZodObject>
-  implements
+export class ProjectedScan<
+  Schema extends ObjectLikeZodType,
+  ProjectedSchema extends ObjectLikeZodType,
+> implements
     BaseCommand<ProjectedScanResult<Schema, ProjectedSchema>, Schema>,
     BasePaginatable<ProjectedScanResult<Schema, ProjectedSchema>, Schema>
 {

--- a/src/commands/put.ts
+++ b/src/commands/put.ts
@@ -1,11 +1,11 @@
 import type { DynamoEntity } from '@/core/entity'
-import type { EntitySchema, TransactWriteOperation } from '@/core'
+import type { EntitySchema, TransactWriteOperation, ObjectLikeZodType } from '@/core'
+import { parsePartial } from '@/core'
 import type {
   ItemCollectionMetrics,
   ReturnItemCollectionMetrics,
   ReturnValue,
 } from '@aws-sdk/client-dynamodb'
-import type { ZodObject } from 'zod/v4'
 import { PutCommand } from '@aws-sdk/lib-dynamodb'
 import type { BaseConfig, BaseCommand, BaseResult, WriteTransactable } from '@/commands'
 
@@ -14,7 +14,7 @@ import type { BaseConfig, BaseCommand, BaseResult, WriteTransactable } from '@/c
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type PutConfig<Schema extends ZodObject> = BaseConfig & {
+export type PutConfig<Schema extends ObjectLikeZodType> = BaseConfig & {
   item: EntitySchema<Schema>
   returnValues?: ReturnValue
   returnItemCollectionMetrics?: ReturnItemCollectionMetrics
@@ -25,7 +25,7 @@ export type PutConfig<Schema extends ZodObject> = BaseConfig & {
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type PutResult<Schema extends ZodObject> = BaseResult & {
+export type PutResult<Schema extends ObjectLikeZodType> = BaseResult & {
   returnItem: Partial<EntitySchema<Schema>> | undefined
   itemCollectionMetrics?: ItemCollectionMetrics
 }
@@ -67,7 +67,7 @@ export type PutResult<Schema extends ZodObject> = BaseResult & {
  * const { returnItem } = await userEntity.send(putCommand);
  * ```
  */
-export class Put<Schema extends ZodObject>
+export class Put<Schema extends ObjectLikeZodType>
   implements BaseCommand<PutResult<Schema>, Schema>, WriteTransactable<Schema>
 {
   #config: PutConfig<Schema>
@@ -82,7 +82,7 @@ export class Put<Schema extends ZodObject>
       : await entity.schema.encodeAsync(this.#config.item)
 
     return {
-      ...encodedData,
+      ...(encodedData as Record<string, unknown>),
       ...entity.buildAllKeys(this.#config.item),
     }
   }
@@ -104,7 +104,7 @@ export class Put<Schema extends ZodObject>
       const returnItem = (
         this.#config.skipValidation
           ? putResult.Attributes
-          : await entity.schema.partial().parseAsync(putResult.Attributes)
+          : await parsePartial(entity.schema, putResult.Attributes)
       ) as Partial<EntitySchema<Schema>>
 
       return {

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -1,8 +1,7 @@
 import type { Condition } from '@/conditions'
 import type { DynamoEntity, EntityKeyInput } from '@/core/entity'
-import type { EntitySchema } from '@/core'
+import type { EntitySchema, ObjectLikeZodType } from '@/core'
 import type { Select } from '@aws-sdk/client-dynamodb'
-import type { ZodObject } from 'zod/v4'
 import type { BaseConfig, BaseCommand, BasePaginatable, BaseResult } from '@/commands'
 import { AttributeExpressionMap } from '@/attributes/attribute-map'
 import { QUERY_VALIDATION_CONCURRENCY } from '@/internal-constants'
@@ -22,7 +21,7 @@ import pMap from 'p-map'
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type QueryConfig<Schema extends ZodObject> = BaseConfig &
+export type QueryConfig<Schema extends ObjectLikeZodType> = BaseConfig &
   EntityKeyInput<EntitySchema<Schema>> & {
     sortKeyCondition?: Condition
     filter?: Condition
@@ -40,7 +39,7 @@ export type QueryConfig<Schema extends ZodObject> = BaseConfig &
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type QueryResult<Schema extends ZodObject> = BaseResult & {
+export type QueryResult<Schema extends ObjectLikeZodType> = BaseResult & {
   items: EntitySchema<Schema>[]
   count: number
   scannedCount: number
@@ -82,7 +81,7 @@ export type QueryResult<Schema extends ZodObject> = BaseResult & {
  * const { items, count } = await todoEntity.send(queryCommand);
  * ```
  */
-export class Query<Schema extends ZodObject>
+export class Query<Schema extends ObjectLikeZodType>
   implements BaseCommand<QueryResult<Schema>, Schema>, BasePaginatable<QueryResult<Schema>, Schema>
 {
   #config: QueryConfig<Schema>

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,8 +1,7 @@
 import type { Condition } from '@/conditions'
 import type { DynamoEntity } from '@/core/entity'
-import type { EntitySchema } from '@/core'
+import type { EntitySchema, ObjectLikeZodType } from '@/core'
 import type { Select } from '@aws-sdk/client-dynamodb'
-import type { ZodObject } from 'zod/v4'
 import { AttributeExpressionMap } from '@/attributes/attribute-map'
 import type { BaseCommand, BaseConfig, BasePaginatable, BaseResult } from '@/commands'
 import { SCAN_VALIDATION_CONCURRENCY } from '@/internal-constants'
@@ -21,7 +20,7 @@ import pMap from 'p-map'
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type ScanConfig<Schema extends ZodObject> = BaseConfig & {
+export type ScanConfig<Schema extends ObjectLikeZodType> = BaseConfig & {
   indexName?: string
   filter?: Condition
   limit?: number
@@ -39,7 +38,7 @@ export type ScanConfig<Schema extends ZodObject> = BaseConfig & {
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type ScanResult<Schema extends ZodObject> = BaseResult & {
+export type ScanResult<Schema extends ObjectLikeZodType> = BaseResult & {
   items: EntitySchema<Schema>[]
   count: number
   scannedCount: number
@@ -79,7 +78,7 @@ export type ScanResult<Schema extends ZodObject> = BaseResult & {
  * const { items, scannedCount } = await todoEntity.send(scanCommand);
  * ```
  */
-export class Scan<Schema extends ZodObject>
+export class Scan<Schema extends ObjectLikeZodType>
   implements BaseCommand<ScanResult<Schema>, Schema>, BasePaginatable<ScanResult<Schema>, Schema>
 {
   #config: ScanConfig<Schema> | undefined

--- a/src/commands/table-batch-get.ts
+++ b/src/commands/table-batch-get.ts
@@ -1,9 +1,8 @@
 import type { BaseConfig, TableCommand, PreparedBatchGet } from '@/commands'
-import type { EntitySchema } from '@/core'
+import type { EntitySchema, ObjectLikeZodType } from '@/core'
 import type { DynamoTable } from '@/core/table'
 import type { ConsumedCapacity } from '@aws-sdk/client-dynamodb'
 import type { ResponseMetadata } from '@aws-sdk/types'
-import type { ZodObject } from 'zod/v4'
 import { DocumentBuilderError } from '@/errors'
 import { BatchGetCommand } from '@aws-sdk/lib-dynamodb'
 import { BATCH_GET_VALIDATION_CONCURRENCY } from '@/internal-constants'
@@ -18,14 +17,14 @@ type ExtractSchema<T> = T extends PreparedBatchGet<infer S> ? EntitySchema<S> : 
 /**
  * Maps an array of PreparedBatchGets to a tuple of their result item arrays.
  */
-type TableBatchGetItems<Gets extends PreparedBatchGet<ZodObject>[]> = {
+type TableBatchGetItems<Gets extends PreparedBatchGet<ObjectLikeZodType>[]> = {
   [K in keyof Gets]: Array<ExtractSchema<Gets[K]>>
 }
 
 /**
  * Maps an array of PreparedBatchGets to a tuple of their unprocessed key arrays.
  */
-type TableBatchGetUnprocessedKeys<Gets extends PreparedBatchGet<ZodObject>[]> = {
+type TableBatchGetUnprocessedKeys<Gets extends PreparedBatchGet<ObjectLikeZodType>[]> = {
   [K in keyof Gets]: Array<Partial<ExtractSchema<Gets[K]>>> | undefined
 }
 

--- a/src/commands/table-batch-write.ts
+++ b/src/commands/table-batch-write.ts
@@ -1,13 +1,12 @@
 import type { BaseConfig, TableCommand, PreparedBatchWrite } from '@/commands'
 import type { DynamoTable } from '@/core/table'
-import type { EntitySchema } from '@/core'
+import type { EntitySchema, ObjectLikeZodType } from '@/core'
 import type {
   ConsumedCapacity,
   ItemCollectionMetrics,
   ReturnItemCollectionMetrics,
 } from '@aws-sdk/client-dynamodb'
 import type { ResponseMetadata } from '@aws-sdk/types'
-import type { ZodObject } from 'zod/v4'
 import { DocumentBuilderError } from '@/errors'
 import { BatchWriteCommand } from '@aws-sdk/lib-dynamodb'
 import { BATCH_WRITE_VALIDATION_CONCURRENCY } from '@/internal-constants'
@@ -22,14 +21,14 @@ type ExtractSchema<T> = T extends PreparedBatchWrite<infer S> ? EntitySchema<S> 
 /**
  * Maps an array of PreparedBatchWrites to a tuple of their unprocessed put arrays.
  */
-type TableBatchWriteUnprocessedPuts<Writes extends PreparedBatchWrite<ZodObject>[]> = {
+type TableBatchWriteUnprocessedPuts<Writes extends PreparedBatchWrite<ObjectLikeZodType>[]> = {
   [K in keyof Writes]: Array<ExtractSchema<Writes[K]>> | undefined
 }
 
 /**
  * Maps an array of PreparedBatchWrites to a tuple of their unprocessed delete arrays.
  */
-type TableBatchWriteUnprocessedDeletes<Writes extends PreparedBatchWrite<ZodObject>[]> = {
+type TableBatchWriteUnprocessedDeletes<Writes extends PreparedBatchWrite<ObjectLikeZodType>[]> = {
   [K in keyof Writes]: Array<Partial<ExtractSchema<Writes[K]>>> | undefined
 }
 

--- a/src/commands/table-transact-get.ts
+++ b/src/commands/table-transact-get.ts
@@ -1,7 +1,6 @@
 import type { BaseConfig, BaseResult, TableCommand, PreparedGetTransaction } from '@/commands'
 import type { DynamoTable } from '@/core/table'
-import type { EntitySchema } from '@/core'
-import type { ZodObject } from 'zod/v4'
+import type { EntitySchema, ObjectLikeZodType } from '@/core'
 import { DocumentBuilderError } from '@/errors'
 import { TransactGetCommand } from '@aws-sdk/lib-dynamodb'
 
@@ -14,7 +13,7 @@ type ExtractSchema<T> = T extends PreparedGetTransaction<infer S> ? EntitySchema
 /**
  * Maps an array of PreparedGetTransactions to a tuple of their result item arrays.
  */
-type TableTransactGetItems<Gets extends PreparedGetTransaction<ZodObject>[]> = {
+type TableTransactGetItems<Gets extends PreparedGetTransaction<ObjectLikeZodType>[]> = {
   [K in keyof Gets]: Array<ExtractSchema<Gets[K]> | undefined>
 }
 
@@ -23,7 +22,7 @@ type TableTransactGetItems<Gets extends PreparedGetTransaction<ZodObject>[]> = {
  *
  * @template Gets - Tuple of PreparedGetTransaction types, one per entity group.
  */
-export type TableTransactGetConfig<Gets extends PreparedGetTransaction<ZodObject>[]> =
+export type TableTransactGetConfig<Gets extends PreparedGetTransaction<ObjectLikeZodType>[]> =
   BaseConfig & {
     gets: [...Gets]
   }
@@ -33,7 +32,7 @@ export type TableTransactGetConfig<Gets extends PreparedGetTransaction<ZodObject
  *
  * @template Gets - Tuple of PreparedGetTransaction types, one per entity group.
  */
-export type TableTransactGetResult<Gets extends PreparedGetTransaction<ZodObject>[]> =
+export type TableTransactGetResult<Gets extends PreparedGetTransaction<ObjectLikeZodType>[]> =
   BaseResult & {
     items: TableTransactGetItems<Gets>
   }
@@ -59,7 +58,7 @@ export type TableTransactGetResult<Gets extends PreparedGetTransaction<ZodObject
  * // orders: (Order | undefined)[]
  * ```
  */
-export class TableTransactGet<Gets extends PreparedGetTransaction<ZodObject>[]>
+export class TableTransactGet<Gets extends PreparedGetTransaction<ObjectLikeZodType>[]>
   implements TableCommand<TableTransactGetResult<Gets>>
 {
   #config: TableTransactGetConfig<Gets>

--- a/src/commands/table-transact-write.ts
+++ b/src/commands/table-transact-write.ts
@@ -6,7 +6,7 @@ import type {
   ReturnItemCollectionMetrics,
 } from '@aws-sdk/client-dynamodb'
 import type { ResponseMetadata } from '@aws-sdk/types'
-import type { ZodObject } from 'zod/v4'
+import type { ObjectLikeZodType } from '@/core'
 import { DocumentBuilderError } from '@/errors'
 import { TransactWriteCommand } from '@aws-sdk/lib-dynamodb'
 import { TRANSACTION_WRITE_VALIDATION_CONCURRENCY } from '@/internal-constants'
@@ -73,7 +73,7 @@ export class TableTransactWrite implements TableCommand<TableTransactWriteResult
     const transactItems = (
       await pMap(
         this.#config.transactions,
-        ({ entity, writes }: PreparedWriteTransaction<ZodObject>) =>
+        ({ entity, writes }: PreparedWriteTransaction<ObjectLikeZodType>) =>
           pMap(writes, write => write.prepareWriteTransaction(entity), {
             concurrency: TRANSACTION_WRITE_VALIDATION_CONCURRENCY,
             signal: this.#config.abortController?.signal,

--- a/src/commands/transact-get.ts
+++ b/src/commands/transact-get.ts
@@ -1,8 +1,7 @@
 import { TransactGetCommand } from '@aws-sdk/lib-dynamodb'
 import type { DynamoEntity } from '@/core/entity'
 import type { BaseConfig, BaseCommand, BaseResult, GetTransactable } from '@/commands'
-import type { ZodObject } from 'zod/v4'
-import type { EntitySchema } from '@/core'
+import type { EntitySchema, ObjectLikeZodType } from '@/core'
 import { TRANSACTION_GET_VALIDATION_CONCURRENCY } from '@/internal-constants'
 import pMap from 'p-map'
 
@@ -11,7 +10,7 @@ import pMap from 'p-map'
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type TransactGetConfig<Schema extends ZodObject> = BaseConfig & {
+export type TransactGetConfig<Schema extends ObjectLikeZodType> = BaseConfig & {
   keys: Array<Partial<EntitySchema<Schema>>>
 }
 
@@ -20,7 +19,7 @@ export type TransactGetConfig<Schema extends ZodObject> = BaseConfig & {
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type TransactGetResult<Schema extends ZodObject> = BaseResult & {
+export type TransactGetResult<Schema extends ObjectLikeZodType> = BaseResult & {
   items: Array<EntitySchema<Schema> | undefined>
 }
 
@@ -59,7 +58,7 @@ export type TransactGetResult<Schema extends ZodObject> = BaseResult & {
  * // items array has same order as keys, undefined if not found
  * ```
  */
-export class TransactGet<Schema extends ZodObject>
+export class TransactGet<Schema extends ObjectLikeZodType>
   implements BaseCommand<TransactGetResult<Schema>, Schema>, GetTransactable<Schema>
 {
   #config: TransactGetConfig<Schema>

--- a/src/commands/transact-write.ts
+++ b/src/commands/transact-write.ts
@@ -6,7 +6,7 @@ import type {
 } from '@aws-sdk/client-dynamodb'
 import type { DynamoEntity } from '@/core/entity'
 import type { ResponseMetadata } from '@aws-sdk/types'
-import type { ZodObject } from 'zod/v4'
+import type { ObjectLikeZodType } from '@/core'
 import { TRANSACTION_WRITE_VALIDATION_CONCURRENCY } from '@/internal-constants'
 import { TransactWriteCommand } from '@aws-sdk/lib-dynamodb'
 import pMap from 'p-map'
@@ -16,7 +16,7 @@ import pMap from 'p-map'
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type TransactWriteConfig<Schema extends ZodObject> = BaseConfig & {
+export type TransactWriteConfig<Schema extends ObjectLikeZodType> = BaseConfig & {
   writes: WriteTransactable<Schema>[]
   idempotencyToken?: string
   returnItemCollectionMetrics?: ReturnItemCollectionMetrics
@@ -68,7 +68,7 @@ export type TransactWriteResult = {
  * await userEntity.send(transactWriteCommand);
  * ```
  */
-export class TransactWrite<Schema extends ZodObject>
+export class TransactWrite<Schema extends ObjectLikeZodType>
   implements BaseCommand<TransactWriteResult, Schema>
 {
   #config: TransactWriteConfig<Schema>

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,12 +1,12 @@
 import type { DynamoEntity } from '@/core/entity'
-import type { EntitySchema, TransactWriteOperation } from '@/core'
+import type { EntitySchema, TransactWriteOperation, ObjectLikeZodType } from '@/core'
+import { parsePartial } from '@/core'
 import type {
   ItemCollectionMetrics,
   ReturnItemCollectionMetrics,
   ReturnValue,
 } from '@aws-sdk/client-dynamodb'
 import type { UpdateValues } from '@/updates'
-import type { ZodObject } from 'zod/v4'
 import { UpdateCommand } from '@aws-sdk/lib-dynamodb'
 import { parseUpdate } from '@/updates/update-parser'
 import type { BaseConfig, BaseCommand, BaseResult, WriteTransactable } from '@/commands'
@@ -16,7 +16,7 @@ import type { BaseConfig, BaseCommand, BaseResult, WriteTransactable } from '@/c
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type UpdateConfig<Schema extends ZodObject> = BaseConfig & {
+export type UpdateConfig<Schema extends ObjectLikeZodType> = BaseConfig & {
   key: Partial<EntitySchema<Schema>>
   update: UpdateValues
   returnValues?: ReturnValue
@@ -28,7 +28,7 @@ export type UpdateConfig<Schema extends ZodObject> = BaseConfig & {
  *
  * @template Schema - The Zod schema defining the structure of the entity.
  */
-export type UpdateResult<Schema extends ZodObject> = BaseResult & {
+export type UpdateResult<Schema extends ObjectLikeZodType> = BaseResult & {
   updatedItem?: Partial<EntitySchema<Schema>> | undefined
   itemCollectionMetrics?: ItemCollectionMetrics
 }
@@ -70,7 +70,7 @@ export type UpdateResult<Schema extends ZodObject> = BaseResult & {
  * const { updatedItem } = await userEntity.send(updateCommand);
  * ```
  */
-export class Update<Schema extends ZodObject>
+export class Update<Schema extends ObjectLikeZodType>
   implements BaseCommand<UpdateResult<Schema>, Schema>, WriteTransactable<Schema>
 {
   #config: UpdateConfig<Schema>
@@ -102,9 +102,7 @@ export class Update<Schema extends ZodObject>
       if (this.#config.skipValidation) {
         updatedItem = updateResult.Attributes as Partial<EntitySchema<Schema>>
       } else {
-        updatedItem = (await entity.schema
-          .partial()
-          .parseAsync(updateResult.Attributes)) as Partial<EntitySchema<Schema>>
+        updatedItem = await parsePartial(entity.schema, updateResult.Attributes)
       }
     }
 

--- a/src/core/entity.ts
+++ b/src/core/entity.ts
@@ -19,8 +19,7 @@ import type {
   DynamoIndexKey,
 } from '@/core/key'
 import type { DynamoTable } from '@/core/table'
-import type { ZodObject } from 'zod/v4'
-import type { EntitySchema, IndexName } from '@/core'
+import type { EntitySchema, IndexName, ObjectLikeZodType } from '@/core'
 import { DocumentBuilderError } from '@/errors'
 
 /**
@@ -35,7 +34,7 @@ import { DocumentBuilderError } from '@/errors'
  * @property globalSecondaryIndexes - Mapping of global secondary index names to their key builders.
  * @property localSecondaryIndexes - Mapping of local secondary index names to their key builders.
  */
-export type DynamoEntityConfig<Schema extends ZodObject> = {
+export type DynamoEntityConfig<Schema extends ObjectLikeZodType> = {
   table: DynamoTable
   schema: Schema
   partitionKey?: DynamoKeyBuilder<EntitySchema<Schema>>
@@ -65,7 +64,7 @@ export type EntityKeyInput<Item> =
  *
  * @template Schema - The Zod schema representing the entity's structure.
  */
-export class DynamoEntity<Schema extends ZodObject> {
+export class DynamoEntity<Schema extends ObjectLikeZodType> {
   #table: DynamoTable
   #schema: Schema
 
@@ -349,7 +348,7 @@ export class DynamoEntity<Schema extends ZodObject> {
                 putRequests.push({
                   PutRequest: {
                     Item: {
-                      ...encodedData,
+                      ...(encodedData as Record<string, unknown>),
                       ...this.buildAllKeys(item),
                     },
                   },

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -2,8 +2,30 @@ export * from './entity'
 export * from './key'
 export * from './table'
 
-import type { output as ZodOutput, input as ZodInput, ZodObject } from 'zod/v4'
+import type { output as ZodOutput, input as ZodInput, ZodType } from 'zod/v4'
 import type { DynamoEntity } from '@/core/entity'
+
+/**
+ * Constrains a Zod schema to types whose output is an object (record of key-value pairs).
+ *
+ * This is broader than `ZodObject` — it also accepts discriminated unions,
+ * unions of objects, intersections, and other Zod types that produce object outputs.
+ */
+export type ObjectLikeZodType = ZodType<Record<string, unknown>>
+
+/**
+ * Parses a partial object from a schema, calling `.partial()` when available (ZodObject)
+ * and falling back to `.parseAsync()` for other object-like schemas.
+ */
+export async function parsePartial<Schema extends ObjectLikeZodType>(
+  schema: Schema,
+  data: unknown,
+): Promise<Partial<EntitySchema<Schema>>> {
+  if ('partial' in schema && typeof schema.partial === 'function') {
+    return (await schema.partial().parseAsync(data)) as Partial<EntitySchema<Schema>>
+  }
+  return (await schema.parseAsync(data)) as Partial<EntitySchema<Schema>>
+}
 import type {
   ConditionCheck,
   Delete,
@@ -18,14 +40,14 @@ import type { NativeAttributeValue } from '@aws-sdk/lib-dynamodb'
  *
  * To get the schema type from an entity use [`Entity<E>`](/api-reference/type-aliases/entity) instead.
  */
-export type EntitySchema<Schema extends ZodObject> = ZodOutput<Schema>
+export type EntitySchema<Schema extends ObjectLikeZodType> = ZodOutput<Schema>
 
 /**
  * Utility type used to derive the input type from the Zod schema definition. Mainly for internal use.
  *
  * To get the input schema type from an entity use [`EncodedEntity<E>`](/api-reference/type-aliases/encodedentity) instead.
  */
-export type EncodedEntitySchema<Schema extends ZodObject> = ZodInput<Schema>
+export type EncodedEntitySchema<Schema extends ObjectLikeZodType> = ZodInput<Schema>
 
 /**
  * Utility type to derive the type of a DynamoEntity's schema.


### PR DESCRIPTION
## Summary

- Replace `Schema extends ZodObject` constraint with `Schema extends ObjectLikeZodType` (`ZodType<Record<string, unknown>>`) across all entity and command types, enabling support for discriminated unions, unions of objects, intersections, and other Zod types that produce object outputs.
- Add `parsePartial` helper to handle partial validation for non-ZodObject schemas (calls `.partial()` when available, falls back to `.parseAsync()`).
- Cast `encodeAsync()` results to `Record<string, unknown>` at spread sites where TS cannot prove the generic input type is spreadable.

## Testing

All 332 existing tests pass. `tsc --noEmit` reports 0 errors.